### PR TITLE
sdl2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/*
 openfight*
 cmake*
 .idea
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(GLU REQUIRED)
 pkg_check_modules(SDL2 REQUIRED sdl2)
 pkg_check_modules(SDL2_IMAGE REQUIRED SDL2_image)
 find_package(LibXml2 REQUIRED)
-find_package(GLEW REQUIRED)
+find_package(GLEW REQUIRED CONFIG)
 
 include_directories(
     ${PROJECT_SOURCE_DIR}/include
@@ -40,7 +40,7 @@ target_link_libraries(
     ${SDL2_IMAGE_LIBRARIES}
     ${LIBXML2_LIBRARIES}
     ${GLEW_LIBRARIES}
-    GLU
+    GLEW::GLEW
 )
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,12 @@ find_package(GLU REQUIRED)
 pkg_check_modules(SDL2 REQUIRED sdl2)
 pkg_check_modules(SDL2_IMAGE REQUIRED SDL2_image)
 find_package(LibXml2 REQUIRED)
-find_package(GLEW REQUIRED CONFIG)
+
+if(APPLE)
+    find_package(GLEW REQUIRED CONFIG)
+else()
+    find_package(GLEW REQUIRED)
+endif()
 
 include_directories(
     ${PROJECT_SOURCE_DIR}/include
@@ -35,12 +40,12 @@ add_executable(${PROJECT_NAME} ${SOURCE} ${HEADER})
 target_link_libraries(
     ${PROJECT_NAME}
     ${OPENGL_gl_LIBRARY}
-    ${GLU_LIBRARIES}
+    ${GLU_LIBRARY}
+    ${GLEW_LIBRARIES}
+    GLEW::GLEW
     ${SDL2_LIBRARIES}
     ${SDL2_IMAGE_LIBRARIES}
     ${LIBXML2_LIBRARIES}
-    ${GLEW_LIBRARIES}
-    GLEW::GLEW
 )
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,36 +1,50 @@
+cmake_minimum_required(VERSION 3.10...3.27)
 project(openfight)
-
-cmake_minimum_required(VERSION 3.5)
 
 file(GLOB SOURCE src/*.cpp)
 file(GLOB HEADER src/*.h)
 
 set(OpenGL_GL_PREFERENCE LEGACY)
+
 find_package(OpenGL REQUIRED)
-find_package(SDL REQUIRED)
-find_package(SDL_image REQUIRED)
+find_package(PkgConfig REQUIRED)
+find_package(GLU REQUIRED)
+pkg_check_modules(SDL2 REQUIRED sdl2)
+pkg_check_modules(SDL2_IMAGE REQUIRED SDL2_image)
 find_package(LibXml2 REQUIRED)
+find_package(GLEW REQUIRED)
 
 include_directories(
     ${PROJECT_SOURCE_DIR}/include
     ${OPENGL_INCLUDE_DIR}
-    ${SDL_INCLUDE_DIR}
-    ${SDL_IMAGE_INCLUDE_DIR}
-    ${LIBXML2_INCLUDE_DIR})
+    ${GLU_INCLUDE_DIRS}
+    ${SDL2_INCLUDE_DIRS}
+    ${SDL2_IMAGE_INCLUDE_DIRS}
+    ${LIBXML2_INCLUDE_DIR}
+    ${GLEW_INCLUDE_DIRS}
+)
+
+link_directories(
+    ${SDL2_LIBRARY_DIRS}
+    ${SDL2_IMAGE_LIBRARY_DIRS}
+    ${GLEW_LIBRARY_DIRS}
+)
 
 add_executable(${PROJECT_NAME} ${SOURCE} ${HEADER})
 
 target_link_libraries(
     ${PROJECT_NAME}
-    ${OPENGL_LIBRARY}
-    ${SDL_LIBRARY}
-    ${SDL_IMAGE_LIBRARIES}
+    ${OPENGL_gl_LIBRARY}
+    ${GLU_LIBRARIES}
+    ${SDL2_LIBRARIES}
+    ${SDL2_IMAGE_LIBRARIES}
     ${LIBXML2_LIBRARIES}
+    ${GLEW_LIBRARIES}
+    GLU
 )
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
             $<TARGET_FILE:${PROJECT_NAME}>
             ${CMAKE_CURRENT_BINARY_DIR}/..
-    COMMENT "Copying openfight to parent directory after build"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.10...3.27)
 project(openfight)
 
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+endif()
+
 file(GLOB SOURCE src/*.cpp)
 file(GLOB HEADER src/*.h)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.10...3.27)
 project(openfight)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+    add_compile_options(-fsanitize=address -fsanitize=undefined)
+    add_link_options(-fsanitize=address -fsanitize=undefined)
 endif()
 
 file(GLOB SOURCE src/*.cpp)

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,4 @@ RUN apt update -y \
     gcc-mingw-w64-i686 g++-mingw-w64-i686 \
     gcc-multilib-i686-linux-gnu g++-multilib-i686-linux-gnu \
     clang \
-    libsdl1.2-dev libsdl-ttf2.0-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-net1.2-dev \
-    libxml2-dev libglu1-mesa-dev
+    libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libxml2-dev libglu1-mesa-dev libglew-dev

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MAIN       := openfight
 IMAGE_NAME := openfight-compiler
 
 compile: clean
-	${CMAKE} -Bbuild
+	${CMAKE} -Bbuild -DCMAKE_BUILD_TYPE=Release
 	${CMAKE} --build build
 	
 docker:

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 CMAKE      := $(shell command -v cmake)
+DOCKER     := $(shell command -v docker)
 MAIN       := openfight
 IMAGE_NAME := openfight-compiler
+BUILD_TYPE ?= Release
 
 compile: clean
-	${CMAKE} -Bbuild -DCMAKE_BUILD_TYPE=Release
+	${CMAKE} -Bbuild -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
 	${CMAKE} --build build
 	
 docker:
-	docker build . -t ${IMAGE_NAME}
+	${DOCKER} build . -t ${IMAGE_NAME}
 
 UNAME := $(shell uname)
 ifeq ($(UNAME), Windows)
@@ -19,7 +21,7 @@ else
 endif
 
 shell:	docker
-	docker run -it --rm -v `pwd`:/tmp/workdir --user ${UID}:${GID} -w /tmp/workdir ${IMAGE_NAME} bash
+	${DOCKER} run -it --rm -v `pwd`:/tmp/workdir --user ${UID}:${GID} -w /tmp/workdir ${IMAGE_NAME} bash
 
 zip:
 	zip -r ${MAIN}-${PLATFORM}.zip data ${MAIN} ${MAIN}.exe
@@ -35,3 +37,6 @@ mac:
 
 clean:
 	rm -rf ${MAIN} *.exe *.o build/*
+
+check-leak:
+	valgrind --leak-check=full --leak-check=full --show-leak-kinds=all  --track-origins=yes ./openfight

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The project can be built using cmake.
 
 To build in ubuntu, install the required packages:
 
-    sudo apt install build-essential libxml2-dev libsdl1.2-dev libsdl-image1.2-dev libglu1-mesa-dev
+    sudo apt install build-essential libxml2-dev libsdl2-dev libsdl-image2-dev libglu1-mesa-dev libglew-dev
 
 Create a directory that is used for the build and generates the platform-specific makefiles:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To build in ubuntu, install the required packages:
 
     sudo apt install build-essential libxml2-dev libsdl2-dev libsdl-image2-dev libglu1-mesa-dev libglew-dev
 
-Create a directory that is used for the build and generates the platform-specific makefiles:
+Create a directory used for the build and generates the platform-specific makefiles:
 
     cmake -Bbuild
     cmake --build build

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The project can be built using cmake.
 
 To build in ubuntu, install the required packages:
 
-    sudo apt install build-essential libxml2-dev libsdl2-dev libsdl-image2-dev libglu1-mesa-dev libglew-dev
+    sudo apt install build-essential libxml2-dev libsdl2-dev libsdl2-image-dev libglu1-mesa-dev libglew-dev
 
 Create a directory used for the build and generates the platform-specific makefiles:
 

--- a/data/config.xml
+++ b/data/config.xml
@@ -13,10 +13,10 @@
       <key_z device = "keyboard" key="46"/>
    </player_one>
    <player_two>
-      <key_up device = "keyboard" key="273"/>
-      <key_down device = "keyboard" key="274"/>
-      <key_left device = "keyboard" key="276"/>
-      <key_right device = "keyboard" key="275"/>
+      <key_up device = "keyboard" key="1073741906"/>
+      <key_down device = "keyboard" key="1073741905"/>
+      <key_left device = "keyboard" key="1073741904"/>
+      <key_right device = "keyboard" key="1073741903"/>
       <key_a device = "keyboard" key="260"/>
       <key_b device = "keyboard" key="261"/>
       <key_c device = "keyboard" key="262"/>

--- a/data/ryu/ryu.xml
+++ b/data/ryu/ryu.xml
@@ -137,13 +137,13 @@
          <defense x_pos="4" y_pos="4" width="12" height="30"/>
       </frame>
    </animation>
-   <animation name="stop_walk">
+   <animation name="stop_walk" show_hitbox="true">
       <frame path="data/ryu/idle00.png" width="20" height="40" delay="1">
          <move x_vel="0" y_vel="0"/>
          <defense x_pos="4" y_pos="4" width="12" height="30"/>
       </frame>
    </animation>
-   <animation name="walk_forward" continual="true">
+   <animation name="walk_forward" continual="true" show_hitbox="true">
       <frame path="data/ryu/walk_forward00.png" width="20" height="40" delay="10">
          <move x_vel="0.2" y_vel="0"/>
          <defense x_pos="4" y_pos="4" width="12" height="30"/>
@@ -177,7 +177,7 @@
          <defense x_pos="4" y_pos="4" width="12" height="30"/>
       </frame>
    </animation>
-   <animation name="run" continual="true">
+   <animation name="run" continual="true" show_hitbox="true">
       <frame path="data/ryu/running00.png" width="40" height="40" delay="10">
          <move x_vel="0.8" y_vel="0"/>
          <defense x_pos="14" y_pos="4" width="12" height="30"/>
@@ -203,7 +203,7 @@
          <defense x_pos="14" y_pos="4" width="12" height="30"/>
       </frame>
    </animation>
-   <animation name="start_duck">
+   <animation name="start_duck" show_hitbox="true">
       <frame path="data/ryu/duck00.png" width="20" height="40" delay="2">
          <move x_vel="0" y_vel="0"/>
          <defense x_pos="4" y_pos="4" width="12" height="20"/>
@@ -213,7 +213,7 @@
          <defense x_pos="4" y_pos="4" width="12" height="20"/>
       </frame>
    </animation>
-   <animation name="end_duck">
+   <animation name="end_duck" show_hitbox="true">
       <frame path="data/ryu/duck01.png" width="20" height="40" delay="2">
          <move x_vel="0" y_vel="0"/>
          <defense x_pos="4" y_pos="4" width="12" height="20"/>
@@ -223,13 +223,13 @@
          <defense x_pos="4" y_pos="4" width="12" height="20"/>
       </frame>
    </animation>
-   <animation name="duck_back" continual="true">
+   <animation name="duck_back" continual="true" show_hitbox="true">
       <frame path="data/ryu/duck02.png" width="20" height="40" delay="0">
          <move x_vel="0" y_vel="0"/>
          <defense x_pos="4" y_pos="4" width="12" height="20"/>
       </frame>
    </animation>
-   <animation name="duck" continual="true">
+   <animation name="duck" continual="true" show_hitbox="true">
       <frame path="data/ryu/duck02.png" width="20" height="40" delay="0">
          <move x_vel="0" y_vel="0"/>
          <defense x_pos="4" y_pos="4" width="12" height="20"/>
@@ -419,7 +419,7 @@
          <defense x_pos="14" y_pos="4" width="12" height="30"/>
       </frame>
    </animation>
-   <animation name="hurt_mid">
+   <animation name="hurt_mid" show_hitbox="true">
       <frame path="data/ryu/hurt00.png" width="40" height="40" delay="2">
          <move x_vel="-0.1" y_vel="0"/>
          <defense x_pos="14" y_pos="4" width="12" height="30"/>
@@ -437,7 +437,7 @@
          <defense x_pos="14" y_pos="4" width="12" height="30"/>
       </frame>
    </animation>
-   <animation name="hurt_high">
+   <animation name="hurt_high" show_hitbox="true">
       <frame path="data/ryu/hurt00.png" width="40" height="40" delay="2">
          <move x_vel="-0.1" y_vel="0"/>
          <defense x_pos="14" y_pos="4" width="12" height="30"/>
@@ -455,7 +455,7 @@
          <defense x_pos="14" y_pos="4" width="12" height="30"/>
       </frame>
    </animation>
-   <animation name="hurt_air">
+   <animation name="hurt_air" show_hitbox="true">
       <frame path="data/ryu/thrown00.png" width="40" height="40" delay="10">
          <move x_vel="-.4" y_vel=".8"/>
          <defense x_pos="14" y_pos="4" width="12" height="30"/>
@@ -477,7 +477,7 @@
          <defense x_pos="14" y_pos="4" width="12" height="30"/>
       </frame>
    </animation>
-   <animation name="dash_back">
+   <animation name="dash_back" show_hitbox="true">
       <frame path="data/ryu/dash_back00.png" width="40" height="40" delay="4">
          <move x_vel="-1.2" y_vel="0"/>
          <defense x_pos="14" y_pos="4" width="12" height="30"/>
@@ -491,7 +491,7 @@
          <defense x_pos="14" y_pos="4" width="12" height="30"/>
       </frame>
    </animation>
-   <animation name="dash_forward">
+   <animation name="dash_forward" show_hitbox="true">
       <frame path="data/ryu/dash_forward00.png" width="40" height="40" delay="2">
          <move x_vel="1.4" y_vel="0"/>
          <defense x_pos="14" y_pos="4" width="12" height="30"/>
@@ -513,7 +513,7 @@
          <defense x_pos="4" y_pos="4" width="12" height="30"/>
       </frame>
    </animation>
-   <animation name="1punch" combo="true">
+   <animation name="1punch" combo="true" show_hitbox="true">
       <frame path="data/ryu/1punch00.png" width="40" height="40" delay="4">
          <move x_vel="0" y_vel="0"/>
          <defense x_pos="14" y_pos="4" width="12" height="30"/>
@@ -565,7 +565,7 @@
       <defense x_pos="14" y_pos="4" width="12" height="30"/>
    </frame>
 </animation>
-<animation name="back_kick">
+<animation name="back_kick" show_hitbox="true">
    <frame path="data/ryu/back_kick00.png" width="40" height="40" delay="4">
       <move x_vel="0" y_vel="0"/>
       <defense x_pos="14" y_pos="4" width="12" height="30"/>
@@ -601,7 +601,7 @@
       <defense x_pos="14" y_pos="4" width="12" height="30"/>
    </frame>
 </animation>
-<animation name="kick">
+<animation name="kick" show_hitbox="true">
    <frame path="data/ryu/kick00.png" width="20" height="40" delay="4">
       <move x_vel="0" y_vel="0"/>
       <defense x_pos="4" y_pos="4" width="12" height="30"/>
@@ -633,7 +633,7 @@
       <defense x_pos="4" y_pos="4" width="12" height="30"/>
    </frame>
 </animation>
-<animation name="grab">
+<animation name="grab" show_hitbox="true">
    <frame path="data/ryu/grab00.png" width="40" height="40" delay="4">
       <move x_vel="0" y_vel="0"/>
       <defense x_pos="14" y_pos="4" width="12" height="30"/>
@@ -653,7 +653,7 @@
       <defense x_pos="14" y_pos="4" width="12" height="30"/>
    </frame>
 </animation>
-<animation name="throw">
+<animation name="throw" show_hitbox="true">
    <frame path="data/ryu/throw00.png" width="40" height="40" delay="4">
       <move x_vel="0" y_vel="0"/>
       <defense x_pos="14" y_pos="4" width="12" height="30"/>
@@ -717,7 +717,7 @@
       <defense x_pos="14" y_pos="4" width="12" height="30"/>
    </frame>
 </animation>
-<animation name="thrown">
+<animation name="thrown" show_hitbox="true">
    <frame path="data/ryu/hurt00.png" width="40" height="40" delay="10">
       <move x_vel="0" y_vel="0"/>
       <defense x_pos="14" y_pos="4" width="12" height="30"/>
@@ -747,7 +747,7 @@
       <defense x_pos="14" y_pos="4" width="12" height="30"/>
    </frame>
 </animation>
-<animation name="hit_ground">
+<animation name="hit_ground" show_hitbox="true">
    <move x_vel="0" y_vel="0"/>
    <frame path="data/ryu/knock_down03.png" width="40" height="40" delay="10">
       <move x_vel="0" y_vel="0"/>

--- a/include/actions.h
+++ b/include/actions.h
@@ -4,10 +4,9 @@
 #include <iostream>
 #include <string>
 #include <typeinfo>
-#include <map>
 #include <vector>
-#include <SDL/SDL.h>
-#include <SDL/SDL_opengl.h>
+#include <GL/glew.h>
+#include <GL/gl.h>
 
 class Player;
 

--- a/include/actions.h
+++ b/include/actions.h
@@ -14,7 +14,7 @@ class Action
 {
    public:
       Action();
-      ~Action();
+      virtual ~Action() = default;
 
       virtual void doAction(Player *player, Player *opponent) = 0;
 };
@@ -27,7 +27,7 @@ class MoveAction : public Action
 
    public:
       MoveAction(GLfloat x_vel, GLfloat y_vel);
-      ~MoveAction();
+      virtual ~MoveAction() = default;
 
       void doAction(Player *player, Player *opponent);
 };
@@ -42,7 +42,7 @@ class CreateObjectAction : public Action
 
    public:
       CreateObjectAction(std::string object, GLfloat x_pos, GLfloat y_pos, int index);
-      ~CreateObjectAction();
+      virtual ~CreateObjectAction() = default;
 
       void doAction(Player *player, Player *opponent);
 };
@@ -59,7 +59,7 @@ class CollisionAction : public Action
 
    public:
       CollisionAction(std::string object, GLfloat x_pos, GLfloat y_pos, int index, std::string to, std::string to_opponent);
-      ~CollisionAction();
+      virtual ~CollisionAction() = default;
 
       void doAction(Player *player, Player *opponent);
 };

--- a/include/animation.h
+++ b/include/animation.h
@@ -1,17 +1,15 @@
 #ifndef _animation_h
 #define _animation_h
 
-#include <iostream>
 #include <string>
 #include <vector>
-#include <SDL/SDL.h>
-#include <SDL/SDL_opengl.h>
-#include <SDL/SDL_image.h>
-#include "utilities.h"
+#include <SDL2/SDL.h>
+#include <GL/glew.h>
+#include <GL/gl.h>
+
 #include "sprite.h"
 #include "collision.h"
 #include "actions.h"
-#include "graphicsCore.h"
 
 
 class Animation

--- a/include/camera.h
+++ b/include/camera.h
@@ -1,7 +1,8 @@
 #ifndef _camera_h
 #define _camera_h
 
-#include <SDL/SDL_opengl.h>
+#include <GL/glew.h>
+#include <GL/gl.h>
 
 class Camera
 {

--- a/include/collision.h
+++ b/include/collision.h
@@ -1,12 +1,10 @@
 #ifndef _collision_h
 #define _collision_h
 
-#include <iostream>
-#include <string>
 #include <vector>
-#include <SDL/SDL.h>
-#include <SDL/SDL_opengl.h>
-#include <SDL/SDL_image.h>
+#include <GL/glew.h>
+#include <GL/gl.h>
+
 #include "collisionBox.h"
 
 class Collision

--- a/include/collisionBox.h
+++ b/include/collisionBox.h
@@ -1,7 +1,6 @@
 #ifndef _collision_box_h
 #define _collision_box_h
 
-#include <SDL/SDL_opengl.h>
 #include "graphicsCore.h"
 
 class CollisionBox

--- a/include/graphics.h
+++ b/include/graphics.h
@@ -1,7 +1,10 @@
 #ifndef _graphics_h
 #define _graphics_h
 
-#include <SDL/SDL_opengl.h>
+#include <GL/glew.h>
+#include <GL/gl.h>
+
+#include <SDL2/SDL_opengl.h>
 
 class Graphics
 {

--- a/include/input.h
+++ b/include/input.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <sstream>
 #include <vector>
-#include <SDL/SDL.h>
+#include <SDL2/SDL.h>
 
 enum Keys 
 { 
@@ -47,7 +47,8 @@ class Input
       void addPlayer();
       void addPlayer(int *config_keys, std::string *config_device);
 
-      SDL_Event poll();
+//      SDL_Event poll(SDL_Event event);
+      void poll(const SDL_Event& event);
       bool *getKeys(int player);
       bool  quitGame();
       static std::string getKeyName(int key);

--- a/include/input.h
+++ b/include/input.h
@@ -47,7 +47,6 @@ class Input
       void addPlayer();
       void addPlayer(int *config_keys, std::string *config_device);
 
-//      SDL_Event poll(SDL_Event event);
       void poll(const SDL_Event& event);
       bool *getKeys(int player);
       bool  quitGame();

--- a/include/input.h
+++ b/include/input.h
@@ -47,7 +47,7 @@ class Input
       void addPlayer();
       void addPlayer(int *config_keys, std::string *config_device);
 
-      void poll(const SDL_Event& event);
+      SDL_Event poll();
       bool *getKeys(int player);
       bool  quitGame();
       static std::string getKeyName(int key);

--- a/include/keyState.h
+++ b/include/keyState.h
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <string>
 #include <list>
-#include <SDL/SDL.h>
+#include <SDL2/SDL.h>
 #include "input.h"
 
 class KeyState

--- a/include/player.h
+++ b/include/player.h
@@ -9,12 +9,16 @@
 #include <map>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
-#include <SDL/SDL_opengl.h>
+#include <GL/glew.h>
+#include <GL/gl.h>
+
+#include <SDL2/SDL_opengl.h>
 #include "objectManager.h"
 #include "graphicsCore.h"
 #include "collision.h"
 #include "actions.h"
 #include "animation.h"
+#include "utilities.h"
 
 
 class Player

--- a/include/playerAgent.h
+++ b/include/playerAgent.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <list>
 #include <map>
+#include <memory>
 #include <vector>
 #include "input.h"
 #include "keyState.h"
@@ -13,8 +14,8 @@
 class PlayerAgent
 {
    private:
-      Player *player;
-      Moves *moves;
+      std::shared_ptr<Player> player;
+      std::unique_ptr<Moves> moves;
       static const int QUEUE_KEY_MAX   = 20;
       static const int INPUT_FRAME_MAX = 10;
       bool previous_keys[KEY_MAX];
@@ -24,9 +25,9 @@ class PlayerAgent
 
    public:
       PlayerAgent();
-      ~PlayerAgent();
+      virtual ~PlayerAgent() = default;
 
-      Player *getPlayer();
+      std::shared_ptr<Player> getPlayer();
       bool initialize(std::string file_name, std::string moves_file, bool player_one);
       void update( bool *keys );
       void draw();

--- a/include/playerBridge.h
+++ b/include/playerBridge.h
@@ -5,7 +5,10 @@
 #include <cmath>
 #include <algorithm>
 #include <iostream>
-#include <SDL/SDL_opengl.h>
+#include <GL/glew.h>
+#include <GL/gl.h>
+
+#include <SDL2/SDL_opengl.h>
 #include "player.h"
 #include "graphicsCore.h"
 

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -1,7 +1,7 @@
 #ifndef _sprite_h
 #define _sprite_h
 
-#include <SDL/SDL_opengl.h>
+#include <SDL2/SDL_opengl.h>
 
 class Sprite
 {

--- a/include/textureManager.h
+++ b/include/textureManager.h
@@ -4,8 +4,10 @@
 #include <map>
 #include <iostream>
 #include <string>
-#include <SDL/SDL_opengl.h>
-#include <SDL/SDL_image.h>
+#include <GL/glew.h>
+#include <GL/gl.h>
+#include <SDL2/SDL_opengl.h>
+#include <SDL2/SDL_image.h>
 
 class TextureManager
 {

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -6,9 +6,12 @@
 #include <vector>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
-#include <SDL/SDL.h>
-#include <SDL/SDL_opengl.h>
-#include <SDL/SDL_image.h>
+#include <SDL2/SDL.h>
+#include <GL/glew.h>
+#include <GL/gl.h>
+
+#include <SDL2/SDL_opengl.h>
+#include <SDL2/SDL_image.h>
 
 extern const float GAME_TIME_UPDATE_FREQ;
 

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -62,19 +62,22 @@ Actions::Actions()
 
 Actions::Actions(const Actions &a)
 {
-   for(int i = 0; i < a.actions.size(); i++)
+   for (int i = 0; i < a.actions.size(); i++)
    {
-      if(typeid(*a.actions[i]) == typeid(CreateObjectAction))
+      Action* act = a.actions[i];
+      if (!act) continue;
+
+      if (typeid(*act) == typeid(CreateObjectAction))
       {
-         actions.push_back(new CreateObjectAction(static_cast<const CreateObjectAction&>(*a.actions[i])));
+         actions.push_back(new CreateObjectAction(static_cast<const CreateObjectAction&>(*act)));
       }
-      else if(typeid(*a.actions[i]) == typeid(CollisionAction))
+      else if (typeid(*act) == typeid(CollisionAction))
       {
-         actions.push_back(new CollisionAction(static_cast<const CollisionAction&>(*a.actions[i])));
+         actions.push_back(new CollisionAction(static_cast<const CollisionAction&>(*act)));
       }
-      else if(typeid(*a.actions[i]) == typeid(MoveAction))
+      else if (typeid(*act) == typeid(MoveAction))
       {
-         actions.push_back(new MoveAction(static_cast<const MoveAction&>(*a.actions[i])));
+         actions.push_back(new MoveAction(static_cast<const MoveAction&>(*act)));
       }
    }
 }
@@ -90,21 +93,21 @@ void Actions::addAction(Action *a)
    actions.push_back(a);
 }
 
-bool Actions::doActions(Player *player, Player *opponent, const type_info& type)
+bool Actions::doActions(Player* player, Player* opponent, const std::type_info& type)
 {
    bool result = false;
 
-   for(int i = 0; i < actions.size(); i++)
+   for (int i = 0; i < actions.size(); i++)
    {
-      if(typeid(*actions[i]) == type)
+      Action* act = actions[i];
+      if (act && typeid(*act) == type)
       {
-         actions[i]->doAction(player, opponent);
+         act->doAction(player, opponent);
          result = true;
       }
    }
 
    return result;
 }
-
 
 

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -7,18 +7,10 @@ Action::Action()
 {
 }
 
-Action::~Action()
-{
-}
-
 MoveAction::MoveAction(GLfloat x_vel, GLfloat y_vel)
 {
    this->x_vel  = x_vel;
    this->y_vel  = y_vel;
-}
-
-MoveAction::~MoveAction()
-{
 }
 
 void MoveAction::doAction(Player *player, Player *opponent)
@@ -35,10 +27,6 @@ CreateObjectAction::CreateObjectAction(string object, GLfloat x_pos, GLfloat y_p
    this->index  = index;
 }
 
-CreateObjectAction::~CreateObjectAction()
-{
-}
-
 void CreateObjectAction::doAction(Player *player, Player *opponent)
 {
    player->copyObject(object, x_pos, y_pos, index);
@@ -52,10 +40,6 @@ CollisionAction::CollisionAction(string object, GLfloat x_pos, GLfloat y_pos, in
    this->index       = index;
    this->to          = to;
    this->to_opponent = to_opponent;
-}
-
-CollisionAction::~CollisionAction()
-{
 }
 
 void CollisionAction::doAction(Player *player, Player *opponent)

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -39,8 +39,17 @@ Animation::~Animation()
    for(int i = 0; i < sprites.size(); i++)
    {
       delete sprites[i];
+   }
+   for(int i = 0; i < offense.size(); i++)
+   {
       delete offense[i];
+   }
+   for(int i = 0; i < defense.size(); i++)
+   {
       delete defense[i];
+   }
+   for(int i = 0; i < action.size(); i++)
+   {
       delete action[i];
    }
 }

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -19,9 +19,9 @@ Animation::Animation(const Animation &a)
    is_combo      = a.is_combo;
    is_continual  = a.is_continual;
    inverted      = a.inverted;
-   x_pos         = x_pos;
-   y_pos         = y_pos;
-   scale         = scale;
+   x_pos         = a.x_pos;
+   y_pos         = a.y_pos;
+   scale         = a.scale;
 
    for(int i = 0; i < a.sprites.size(); i++)
    {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -137,53 +137,72 @@ int Input::getKeyWait(string &device)
    return result;
 }
 
-void Input::poll(const SDL_Event& event)
+SDL_Event Input::poll()
 {
    string device;
    int button = -1;
    bool pressed = false;
 
-   switch (event.type)
+   SDL_Event event;
+
+   SDL_PumpEvents();
+
+   while(SDL_PollEvent(&event))
    {
-      case SDL_QUIT:
-         quit_key = true;
-         break;
 
-      case SDL_KEYDOWN:
-      case SDL_KEYUP:
-         device = deviceName(event);
-         button = event.key.keysym.sym;
-         pressed = (event.type == SDL_KEYDOWN);
-         break;
-
-      case SDL_JOYBUTTONDOWN:
-      case SDL_JOYBUTTONUP:
-         device = deviceName(event);
-         button = event.jbutton.button;
-         pressed = (event.type == SDL_JOYBUTTONDOWN);
-         break;
-
-      case SDL_JOYAXISMOTION:
-         device = deviceName(event);
-         button = event.jaxis.axis;
-         pressed = (event.jaxis.value > 0);
-         break;
-   }
-
-   if (device == "keyboard" && button == SDLK_ESCAPE)
-      quit_key = true;
-
-   for (size_t i = 0; i < playerKeys.size(); i++)
-   {
-      for (int j = 0; j < KEY_MAX; j++)
+      switch (event.type)
       {
-         if (device == playerKeys[i]->config_device[j] &&
-             button == playerKeys[i]->config_keys[j])
+         case SDL_QUIT:
+            quit_key = true;
+            break;
+
+         case SDL_KEYDOWN:
+         case SDL_KEYUP:
+            device = deviceName(event);
+            button = event.key.keysym.sym;
+            pressed = (event.type == SDL_KEYDOWN);
+            break;
+
+         case SDL_JOYBUTTONDOWN:
+         case SDL_JOYBUTTONUP:
+            device = deviceName(event);
+            button = event.jbutton.button;
+            pressed = (event.type == SDL_JOYBUTTONDOWN);
+            break;
+
+         case SDL_JOYAXISMOTION:
+            device = deviceName(event);
+            button = event.jaxis.axis;
+            pressed = (event.jaxis.value > 0);
+            break;
+
+
+         case SDL_WINDOWEVENT:
+            if (event.window.event == SDL_WINDOWEVENT_RESIZED)
+            {
+               return event;
+            }
+            break;
+
+      }
+
+      if (device == "keyboard" && button == SDLK_ESCAPE)
+         quit_key = true;
+
+      for (size_t i = 0; i < playerKeys.size(); i++)
+      {
+         for (int j = 0; j < KEY_MAX; j++)
          {
-            playerKeys[i]->keys[j] = pressed;
+            if (device == playerKeys[i]->config_device[j] &&
+               button == playerKeys[i]->config_keys[j])
+            {
+               playerKeys[i]->keys[j] = pressed;
+            }
          }
       }
    }
+
+   return event;
 }
 
 string Input::getKeyName(int key)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -168,13 +168,6 @@ void Input::poll(const SDL_Event& event)
          button = event.jaxis.axis;
          pressed = (event.jaxis.value > 0);
          break;
-
-      case SDL_WINDOWEVENT:
-         if (event.window.event == SDL_WINDOWEVENT_RESIZED)
-         {
-            // Caso queira tratar o resize, faça aqui, mas não retorne evento.
-         }
-         break;
    }
 
    if (device == "keyboard" && button == SDLK_ESCAPE)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,24 +79,20 @@ int main(int argc, char *argv[])
 
         if (updateGame(game_time))
         {
-            SDL_Event event;
-            while (SDL_PollEvent(&event))
+            SDL_Event event = input.poll();
+
+            if (event.type == SDL_QUIT)
             {
-                input.poll(event);
+                running = false;
+            }
+            else if (event.type == SDL_WINDOWEVENT &&
+                        event.window.event == SDL_WINDOWEVENT_RESIZED)
+            {
+                int sw = event.window.data1;
+                int sh = event.window.data2;
 
-                if (event.type == SDL_QUIT)
-                {
-                    running = false;
-                }
-                else if (event.type == SDL_WINDOWEVENT &&
-                         event.window.event == SDL_WINDOWEVENT_RESIZED)
-                {
-                    int sw = event.window.data1;
-                    int sh = event.window.data2;
-
-                    SDL_SetWindowSize(window, sw, sh);
-                    graphics->resizeWindow(sw, sh);
-                }
+                SDL_SetWindowSize(window, sw, sh);
+                graphics->resizeWindow(sw, sh);
             }
 
             bool *keys = input.getKeys(0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,18 +58,20 @@ int main(int argc, char *argv[])
     PlayerAgent player2;
     player2.initialize("data/ryu/ryu.xml", "data/ryu/moves.xml", false);
 
-    player.getPlayer()->setOpponent(player2.getPlayer());
-    player2.getPlayer()->setOpponent(player.getPlayer());
+    auto p2 = player2.getPlayer().get();
+    auto p1 = player.getPlayer().get();
+    player.getPlayer()->setOpponent(p2);
+    player2.getPlayer()->setOpponent(p1);
 
     Sprite background;
     GLuint texture = texture_manager->addTexture("data/background.png", false);
     background.setTexture(texture, 200, 100);
 
     PlayerBridge bridge;
-    bridge.initialize(player.getPlayer(), player2.getPlayer());
+    bridge.initialize(p1, p2);
 
-    object_manager->add("0", player.getPlayer());
-    object_manager->add("1", player2.getPlayer());
+    object_manager->add("0", p1);
+    object_manager->add("1", p2);
 
     Uint32 lastTime = SDL_GetTicks();
     int frames = 0;
@@ -150,6 +152,7 @@ int main(int argc, char *argv[])
     SDL_GL_DeleteContext(glContext);
     SDL_DestroyWindow(window);
     SDL_Quit();
+
 
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include <SDL/SDL.h>
+#include <SDL2/SDL.h>
 #include "utilities.h"
 #include "input.h"
 #include "animation.h"
@@ -18,113 +18,130 @@ extern "C"
 
 int main(int argc, char *argv[])
 {
-   if( SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) == 1 )
-      return -1;
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) != 0) {
+        return -1;
+    }
 
-   const SDL_VideoInfo *video_info = SDL_GetVideoInfo();
-   if(video_info == NULL)
-      return -1;
+    SDL_Window *window = SDL_CreateWindow("OpenFight",
+                                          SDL_WINDOWPOS_CENTERED,
+                                          SDL_WINDOWPOS_CENTERED,
+                                          screen_width, screen_height,
+                                          SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 
-   atexit(SDL_Quit);
+    if (!window) {
+        SDL_Quit();
+        return -1;
+    }
 
-   int video_flags = SDL_OPENGL | SDL_GL_DOUBLEBUFFER | SDL_HWPALETTE | SDL_RESIZABLE;
+    SDL_GLContext glContext = SDL_GL_CreateContext(window);
+    if (!glContext) {
+        SDL_DestroyWindow(window);
+        SDL_Quit();
+        return -1;
+    }
 
-   if(video_info->hw_available)
-      video_flags |= SDL_HWSURFACE;
-   else
-      video_flags |= SDL_SWSURFACE;
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    SDL_GL_SetSwapInterval(1); // vsync
 
-   if(video_info->blit_hw)
-      video_flags |= SDL_HWACCEL;
+    graphics->initialize(screen_width, screen_height);
 
-   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    Configuration configuration("data/config.xml");
+    configuration.read();
 
-   SDL_SetVideoMode(screen_width, screen_height, screen_bpp, video_flags);
+    Input input;
+    input.addPlayer(configuration.getConfigKeys(true), configuration.getConfigDevice(true));
+    input.addPlayer(configuration.getConfigKeys(false), configuration.getConfigDevice(false));
 
-   SDL_WM_SetCaption("OpenFight", NULL);
+    PlayerAgent player;
+    player.initialize("data/ryu/ryu.xml", "data/ryu/moves.xml", true);
 
-   graphics->initialize(screen_width, screen_height);
+    PlayerAgent player2;
+    player2.initialize("data/ryu/ryu.xml", "data/ryu/moves.xml", false);
 
-   Configuration configuration("data/config.xml");
-   configuration.read();
+    player.getPlayer()->setOpponent(player2.getPlayer());
+    player2.getPlayer()->setOpponent(player.getPlayer());
 
-   Input input;
-   input.addPlayer(configuration.getConfigKeys(true), configuration.getConfigDevice(true));
-   input.addPlayer(configuration.getConfigKeys(false), configuration.getConfigDevice(false));
+    Sprite background;
+    GLuint texture = texture_manager->addTexture("data/background.png", false);
+    background.setTexture(texture, 200, 100);
 
-   PlayerAgent player;
-   player.initialize("data/ryu/ryu.xml", "data/ryu/moves.xml", true);
+    PlayerBridge bridge;
+    bridge.initialize(player.getPlayer(), player2.getPlayer());
 
-   PlayerAgent player2;
-   player2.initialize("data/ryu/ryu.xml","data/ryu/moves.xml",  false);
+    object_manager->add("0", player.getPlayer());
+    object_manager->add("1", player2.getPlayer());
 
-   player.getPlayer()->setOpponent(player2.getPlayer());
-   player2.getPlayer()->setOpponent(player.getPlayer());
+    bool running = true;
 
-   Sprite background;
-   GLuint texture = texture_manager->addTexture("data/background.png", false);
-   background.setTexture(texture,200,100);
+    while (running && !input.quitGame())
+    {
+        float game_time;
 
-   PlayerBridge bridge;
-   bridge.initialize(player.getPlayer(), player2.getPlayer());
+        if (updateGame(game_time))
+        {
+            SDL_Event event;
+            while (SDL_PollEvent(&event))
+            {
+                input.poll(event);
 
-   object_manager->add("0", player.getPlayer());
-   object_manager->add("1", player2.getPlayer());
+                if (event.type == SDL_QUIT)
+                {
+                    running = false;
+                }
+                else if (event.type == SDL_WINDOWEVENT &&
+                         event.window.event == SDL_WINDOWEVENT_RESIZED)
+                {
+                    int sw = event.window.data1;
+                    int sh = event.window.data2;
 
-
-   while(!input.quitGame())
-   {  
-      float game_time;
-
-      if(updateGame(game_time))
-      {
-         SDL_Event event = input.poll();
- 
-         if(event.type == SDL_VIDEORESIZE)
-         {
-            SDL_SetVideoMode(event.resize.w, event.resize.h, screen_bpp, video_flags);
-            graphics->resizeWindow(event.resize.w, event.resize.h);
-         }
-
-         bool *keys = input.getKeys(0);
-         player.update(keys);
-
-         bool *keys2 = input.getKeys(1);
-         player2.update(keys2);
-
-         string key = object_manager->first();
-         while(key != "")
-         {
-            bool done = false;
-
-            if(key != "0" && key != "1")
-               done = object_manager->get(key)->update();
-
-            if (done) {
-                object_manager->remove(key);
-                break;
+                    SDL_SetWindowSize(window, sw, sh);
+                    graphics->resizeWindow(sw, sh);
+                }
             }
 
-            key = object_manager->next();
-         }
+            bool *keys = input.getKeys(0);
+            player.update(keys);
 
-         //draw
-         glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT); // Clear color and depth buffer
+            bool *keys2 = input.getKeys(1);
+            player2.update(keys2);
 
-         glLoadIdentity(); // Reset orientation
-         glTranslatef(-50.0f, -50.0f, -120.0f);
+            string key = object_manager->first();
+            while (key != "")
+            {
+                bool done = false;
 
-         bridge.update();
-         background.draw(50,50,1, false);
+                if (key != "0" && key != "1")
+                    done = object_manager->get(key)->update();
 
-         list<Player*> objects = object_manager->getSortedList();
+                if (done) {
+                    object_manager->remove(key);
+                    break;
+                }
 
-         for(list<Player*>::iterator i = objects.begin(); i != objects.end(); i++)
-            (*i)->draw();
+                key = object_manager->next();
+            }
 
-         SDL_GL_SwapBuffers();
+            // Render
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+            glLoadIdentity();
+            glTranslatef(-50.0f, -50.0f, -120.0f);
 
-         game_time = getGameTime();
-      }
-   }
+            bridge.update();
+            background.draw(50, 50, 1, false);
+
+            list<Player *> objects = object_manager->getSortedList();
+            for (auto i = objects.begin(); i != objects.end(); ++i)
+                (*i)->draw();
+
+            SDL_GL_SwapWindow(window);
+
+            game_time = getGameTime();
+        }
+    }
+
+    SDL_GL_DeleteContext(glContext);
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+
+    return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,6 +71,9 @@ int main(int argc, char *argv[])
     object_manager->add("0", player.getPlayer());
     object_manager->add("1", player2.getPlayer());
 
+    Uint32 lastTime = SDL_GetTicks();
+    int frames = 0;
+
     bool running = true;
 
     while (running && !input.quitGame())
@@ -130,6 +133,15 @@ int main(int argc, char *argv[])
                 (*i)->draw();
 
             SDL_GL_SwapWindow(window);
+
+            frames++;
+            Uint32 currentTime = SDL_GetTicks();
+            if (currentTime > lastTime + 1000) {
+                float fps = frames * 1000.0f / (currentTime - lastTime);
+                printf("FPS: %.2f\n", fps);
+                lastTime = currentTime;
+                frames = 0;
+            }
 
             game_time = getGameTime();
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
     }
 
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-    SDL_GL_SetSwapInterval(1); // vsync
+    SDL_GL_SetSwapInterval(0); // Turn off VSync because it was causing low FPS
 
     graphics->initialize(screen_width, screen_height);
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1,5 +1,4 @@
 #include "player.h"
-#include "global.h"
 
 using namespace std;
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -27,8 +27,8 @@ Player::Player(const Player &p)
 
    type     = p.type;
    inverted = p.inverted;
-   is_hurt  = is_hurt;
-   index    = index;
+   is_hurt  = p.is_hurt;
+   index    = p.index;
 
    current_state  = p.current_state;
    previous_state = p.previous_state;

--- a/src/playerAgent.cpp
+++ b/src/playerAgent.cpp
@@ -6,18 +6,10 @@
 
 using namespace std;
 
-
 PlayerAgent::PlayerAgent()
-{
-}
+    : player(nullptr), moves(nullptr), current_frame(0) {}
 
-PlayerAgent::~PlayerAgent()
-{
-   delete player;
-   delete moves;
-}
-
-Player *PlayerAgent::getPlayer()
+std::shared_ptr<Player> PlayerAgent::getPlayer()
 {
    return player;
 }
@@ -25,10 +17,10 @@ Player *PlayerAgent::getPlayer()
 bool PlayerAgent::initialize(string file_name, string moves_file, bool player_one)
 {
    GLfloat location = player_one ? 30:70;
-   player = new Player();
+   player = std::make_shared<Player>();
    player->initialize(file_name, player_one, location, 0);
 
-   moves = new Moves();
+   moves = std::make_unique<Moves>();
    moves->initialize(moves_file);
 
    for(int i = 0; i < KEY_MAX; i++)

--- a/src/textureManager.cpp
+++ b/src/textureManager.cpp
@@ -1,64 +1,59 @@
 #include "textureManager.h"
+#include <SDL2/SDL_image.h>
+#include <map>
+#include <string>
 
 using namespace std;
 
-TextureManager::TextureManager()
-{
-}
+TextureManager::TextureManager() {}
 
 TextureManager::~TextureManager()
 {
-   map<string, GLuint>::iterator i;
+    for (auto& pair : textures)
+        glDeleteTextures(1, &pair.second);
 
-   for(i = textures.begin(); i != textures.end(); i++)
-      glDeleteTextures(1, &i->second);
-
-   for(i = textures.begin(); i != masks.end(); i++)
-      glDeleteTextures(1, &i->second);
+    for (auto& pair : masks)
+        glDeleteTextures(1, &pair.second);
 }
 
-Uint32 TextureManager::getPixel(SDL_Surface *surface, int x, int y)
+Uint32 TextureManager::getPixel(SDL_Surface* surface, int x, int y)
 {
     int bpp = surface->format->BytesPerPixel;
-    Uint8 *p = (Uint8 *)surface->pixels + y * surface->pitch + x * bpp;
+    Uint8* p = (Uint8*)surface->pixels + y * surface->pitch + x * bpp;
 
-    switch(bpp) {
+    switch (bpp)
+    {
     case 1:
         return *p;
-
     case 2:
-        return *(Uint16 *)p;
-
+        return *(Uint16*)p;
     case 3:
-        if(SDL_BYTEORDER == SDL_BIG_ENDIAN)
+        if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
             return p[0] << 16 | p[1] << 8 | p[2];
         else
             return p[0] | p[1] << 8 | p[2] << 16;
-
     case 4:
-        return *(Uint32 *)p;
-
+        return *(Uint32*)p;
     default:
-        return 0;       /* shouldn't happen, but avoids warnings */
+        return 0;
     }
 }
 
-void TextureManager::setPixel(SDL_Surface *surface, int x, int y, Uint32 pixel)
+void TextureManager::setPixel(SDL_Surface* surface, int x, int y, Uint32 pixel)
 {
     int bpp = surface->format->BytesPerPixel;
-    Uint8 *p = (Uint8 *)surface->pixels + y * surface->pitch + x * bpp;
+    Uint8* p = (Uint8*)surface->pixels + y * surface->pitch + x * bpp;
 
-    switch(bpp) {
+    switch (bpp)
+    {
     case 1:
         *p = pixel;
         break;
-
     case 2:
-        *(Uint16 *)p = pixel;
+        *(Uint16*)p = pixel;
         break;
-
     case 3:
-        if(SDL_BYTEORDER == SDL_BIG_ENDIAN) {
+        if (SDL_BYTEORDER == SDL_BIG_ENDIAN) {
             p[0] = (pixel >> 16) & 0xff;
             p[1] = (pixel >> 8) & 0xff;
             p[2] = pixel & 0xff;
@@ -68,89 +63,81 @@ void TextureManager::setPixel(SDL_Surface *surface, int x, int y, Uint32 pixel)
             p[2] = (pixel >> 16) & 0xff;
         }
         break;
-
     case 4:
-        *(Uint32 *)p = pixel;
+        *(Uint32*)p = pixel;
         break;
     }
 }
 
-void TextureManager::createMask(SDL_Surface *image)
+void TextureManager::createMask(SDL_Surface* image)
 {
-   SDL_LockSurface(image);
-   int color_black = SDL_MapRGB(image->format, 0xff, 0xff, 0xff);
-   int color_white = SDL_MapRGB(image->format, 0x00, 0x00, 0x00);
+    SDL_LockSurface(image);
+    Uint32 color_black = SDL_MapRGB(image->format, 0xff, 0xff, 0xff);
+    Uint32 color_white = SDL_MapRGB(image->format, 0x00, 0x00, 0x00);
 
-   for(int i = 0; i < image->w; i++)
-   {
-      for(int j = 0; j < image->h; j++)
-      {
-         if(getPixel(image,i,j) != 0)
-            setPixel(image, i, j, color_white);
-         else
-            setPixel(image, i, j, color_black);
-      }
-   }
+    for (int x = 0; x < image->w; x++)
+    {
+        for (int y = 0; y < image->h; y++)
+        {
+            if (getPixel(image, x, y) != 0)
+                setPixel(image, x, y, color_white);
+            else
+                setPixel(image, x, y, color_black);
+        }
+    }
 
-   SDL_UnlockSurface(image);
+    SDL_UnlockSurface(image);
 }
 
 GLuint TextureManager::loadTexture(std::string file_name, bool mipmap, bool masking)
 {
-   glPushAttrib (GL_ALL_ATTRIB_BITS);
-   GLuint texture;
-   SDL_Surface* imgFile = IMG_Load(file_name.c_str());
+    GLuint texture;
+    SDL_Surface* imgFile = IMG_Load(file_name.c_str());
 
-   if(imgFile == NULL)
-      return -1; 
+    if (imgFile == nullptr)
+        return 0;
 
-   if(masking)
-      createMask(imgFile);
+    if (masking)
+        createMask(imgFile);
 
-   glGenTextures(1,&texture);
-   glBindTexture(GL_TEXTURE_2D,texture);
+    GLenum texture_format = GL_RGB;
+    if (imgFile->format->BytesPerPixel == 4)
+        texture_format = GL_RGBA;
 
-   if(mipmap)
-   {   
-      // Load mipmap texture
-      glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-      glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_NEAREST);
-      gluBuild2DMipmaps(GL_TEXTURE_2D, 3, imgFile->w, imgFile->h, GL_RGB, GL_UNSIGNED_BYTE, imgFile->pixels);
-   }   
-   else
-   {   
-      // Load normal texture
-      glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-      glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-      glTexImage2D (GL_TEXTURE_2D, 0, 3, imgFile->w, imgFile->h, 0, GL_RGB, GL_UNSIGNED_BYTE, imgFile->pixels);
-   }   
-   glPopAttrib (); 
+    glGenTextures(1, &texture);
+    glBindTexture(GL_TEXTURE_2D, texture);
 
-   SDL_FreeSurface( imgFile );
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipmap ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
-   return texture;
+    // Upload texture to GPU
+    glTexImage2D(
+        GL_TEXTURE_2D, 0,
+        imgFile->format->BytesPerPixel == 4 ? GL_RGBA : GL_RGB,
+        imgFile->w, imgFile->h, 0,
+        texture_format, GL_UNSIGNED_BYTE, imgFile->pixels
+    );
+
+    if (mipmap)
+        glGenerateMipmap(GL_TEXTURE_2D);  // Requires OpenGL >= 3.0 or EXT_framebuffer_object
+
+    SDL_FreeSurface(imgFile);
+
+    return texture;
 }
 
-GLuint TextureManager::addTexture(string file_name, bool mimpmap)
+GLuint TextureManager::addTexture(string file_name, bool mipmap)
 {
-   GLuint result;
+    if (textures.find(file_name) == textures.end())
+        textures[file_name] = loadTexture(file_name, mipmap, false);
 
-   if(textures.find(file_name) == textures.end())
-      result = loadTexture(file_name, mimpmap, false);
-   else
-      result = textures[file_name];
-
-   return result;
+    return textures[file_name];
 }
 
-GLuint TextureManager::addMask(string file_name, bool mimpmap)
+GLuint TextureManager::addMask(string file_name, bool mipmap)
 {
-   GLuint result;
+    if (masks.find(file_name) == masks.end())
+        masks[file_name] = loadTexture(file_name, mipmap, true);
 
-   if(masks.find(file_name) == masks.end())
-      result = loadTexture(file_name, mimpmap, true);
-   else
-      result = masks[file_name];
-
-   return result;
+    return masks[file_name];
 }


### PR DESCRIPTION
The sdl 1.2 is deprecated since 2012. So, i moved to sdl2

## Changes
- Migrated codebase to SDL2 with necessary adjustments
- Implemented showFPS functionality
- Disabled VSync to allow higher frame rates
- Updated Player 2 key mappings for SDL2 compatibility
- Using smart pointer on Actions class to solve memory leak on destructors
- Valgrind added to inspect possible memory leaks


### Linked shared objects
```shell
ldd openfight
        libGL.so.1 => /lib/x86_64-linux-gnu/libGL.so.1 (0x000070e267afc000)
        libSDL2-2.0.so.0 => /lib/x86_64-linux-gnu/libSDL2-2.0.so.0 (0x000070e267800000)
        libSDL2_image-2.0.so.0 => /lib/x86_64-linux-gnu/libSDL2_image-2.0.so.0 (0x000070e267ad3000)
        libxml2.so.2 => /lib/x86_64-linux-gnu/libxml2.so.2 (0x000070e267613000)
        libGLEW.so.2.2 => /lib/x86_64-linux-gnu/libGLEW.so.2.2 (0x000070e267555000)
        libGLU.so.1 => /lib/x86_64-linux-gnu/libGLU.so.1 (0x000070e2674fc000)
```